### PR TITLE
\chapter* を使う

### DIFF
--- a/tex/con_ack.tex
+++ b/tex/con_ack.tex
@@ -7,6 +7,6 @@
 
 \newpage
 
-\section*{\Large 謝辞}
+\chapter*{謝辞}
 \addcontentsline{toc}{chapter}{謝辞}
 感謝、感謝です。

--- a/tex/reference.tex
+++ b/tex/reference.tex
@@ -6,6 +6,6 @@
 
  \newpage
 
- \section*{\Large 発表リスト}
+ \chapter*{発表リスト}
  \addcontentsline{toc}{chapter}{発表リスト}
  \noindent [1] 宮沢賢治『ポラーノの広場』岩手県花巻町, 1934.

--- a/tex/setting.tex
+++ b/tex/setting.tex
@@ -84,7 +84,7 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\def\thebibliography#1{\section*{\Large 参考文献\markboth
+\def\thebibliography#1{\chapter*{参考文献\markboth
  {参 考 文 献}{参 考 文 献}\addcontentsline{toc}{chapter}{参考文献}}\list
  {[\arabic{enumi}]}{\settowidth\labelwidth{[#1]}\leftmargin\labelwidth
  \advance\leftmargin\labelsep
@@ -109,6 +109,17 @@
    \else
      #1\relax
    \fi}\nobreak\vskip1\Cvs}
+\makeatother%%
+
+%schapterのフォントサイズ変更
+\makeatletter%%
+\def\@makeschapterhead#1{\hbox{}%
+  \vskip-1\Cvs
+  {\parindent \z@ \raggedright
+    \normalfont
+    \interlinepenalty\@M
+    \Large\headfont #1\par\nobreak
+    \vskip1\Cvs}}
 \makeatother%%
 
 %sectionのフォントサイズ変更


### PR DESCRIPTION
`\section*{\Large ......}` を `\chapter*{......}` に置換することを提案します。謝辞や参考文献は、文書構造としてはchapterなので、`\chapter*`のフォントサイズを `\chapter` と統一して、それぞれの見出しを修正しました。
