### PR TITLE
教官→教員

### DIFF
--- a/tex/cmember.tex
+++ b/tex/cmember.tex
@@ -14,7 +14,7 @@
 	\begin{tabular}[t]{p{0.3truein}ll}
 	 \multicolumn{2}{l}{審査委員：} \\
 	 & 関 豊太郎 教授 & （主指導教員） \\
-	 & 早坂 一郎 教授 & （副指導教官）
+	 & 早坂 一郎 教授 & （副指導教員）
 	\end{tabular}
  \end{center}
  \end{table}


### PR DESCRIPTION
国立大学法人となってからは教官ではなく教員と呼ぶ方が一般的のようなので教員で統一。
なお早坂氏は東北帝国大学の所属だったので教官としていた。一方、関氏は盛岡高等農林学校の所属であったので
教員にしていたが、[Wikipedia](https://ja.wikipedia.org/wiki/%E7%9B%9B%E5%B2%A1%E9%AB%98%E7%AD%89%E8%BE%B2%E6%9E%97%E5%AD%A6%E6%A0%A1)によると、この高校は官立旧制専門学校だったようなので、
こちらも教官が正解だったのかもしれない。